### PR TITLE
fix function name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Handlebars is nothing without **helpers**.
 
 ### Using javascript helpers
 Helpers can also be defined using javascript. Javascript helpers
-are registered using register-javascript-helpers!-function
+are registered using register-js-helpers!-function
 ```clojure
-(register-javascript-helpers! "path/to/file-js")
+(register-js-helpers! "path/to/file.js")
 ```
 
 ### Helpers defined by me


### PR DESCRIPTION
The function name for register-js-helpers! was incorrect in README. Fixed it. 
