### PR TITLE
Fix remote URL template loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ This library is based on [handlebars.java](https://github.com/jknack/handlebars.
 ;; configure where to load template file:
 (set-template-path! "templates" ".html")
 
+;; OR load templates from a remote URL (defaults to .hbs files):
+(set-template-url! "http://example.com/templates/")
+
 ;; render something from templates/index.html
 (render-file "index" {:foo "bar"})
 ```

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [com.github.jknack/handlebars "2.0.0"]]
+  :profiles {:test {:dependencies [[ring "1.3.2"]]}}
   :java-source-paths ["java"]
   :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
   :plugins [[codox "0.8.10"]]

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,6 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [com.github.jknack/handlebars "2.0.0"]]
   :profiles {:test {:dependencies [[ring "1.3.2"]]}}
-  :java-source-paths ["java"]
-  :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
   :plugins [[codox "0.8.10"]]
   :codox {:output-dir "target/codox"
           :exclude [hbs.ext]}

--- a/test/hbs/core_test.clj
+++ b/test/hbs/core_test.clj
@@ -1,6 +1,7 @@
 (ns hbs.core-test
   (:require [clojure.test :refer :all]
-            [hbs.core :refer :all])
+            [hbs.core :refer :all]
+            [hbs.test-web-server :refer [find-free-port with-test-webserver]])
   (:import [java.util HashMap]))
 
 (deftest test-render
@@ -14,8 +15,14 @@
     (is (= "Handlebars" (render "{{#person}}{{name}}{{/person}}"
                                 {:person p})))))
 
-(set-template-path! "/templates" ".tpl")
-
 (deftest test-render-file
   (testing "test render from file"
+    (set-template-path! "/templates" ".tpl")
     (is (= "Hello World!\n" (render-file "hello" {:name "World"})))))
+
+(deftest test-render-http-file
+  (testing "test render file from HTTP URL"
+    (let [http-port (find-free-port)]
+      (with-test-webserver http-port
+        (set-template-url! (str "http://localhost:" http-port))
+        (is (= "Hello World!" (render-file "hi" {:name "World"})))))))

--- a/test/hbs/test_web_server.clj
+++ b/test/hbs/test_web_server.clj
@@ -1,0 +1,38 @@
+(ns hbs.test-web-server
+  (:require [ring.adapter.jetty :refer [run-jetty]])
+  (:import [java.net ServerSocket]
+           [java.io IOException]))
+
+(defn- open-port [port]
+  (try (ServerSocket. port)
+       (catch IOException e nil)))
+
+(defn find-free-port
+  ([] (find-free-port 49152 65535))
+  ([min-port max-port]
+   (let [ports (range min-port max-port)]
+     (loop [try-port (first ports)
+            rest-ports (rest ports)]
+       (if-let [socket (open-port try-port)]
+         (do
+           (.close socket)
+           try-port)
+         (if (empty? rest-ports)
+           (throw (IOException.
+                   (str "No ports available between " min-port " and " max-port)))
+           (recur (first rest-ports)
+                  (rest rest-ports))))))))
+
+(defn- handler [request]
+  {:status 200
+   :headers {"Content-Type" "text/plain"}
+   :body "Hello {{name}}!"})
+
+(defmacro with-test-webserver
+  [port & body]
+  `(let [server-thread# (Thread. #(run-jetty ~handler {:port ~port
+                                                       :host "localhost"}))]
+     (.start server-thread#)
+     (Thread/sleep 1000)
+     ~@body
+     (.stop server-thread#)))


### PR DESCRIPTION
While it's not the most performant approach (yet), we would like to try loading templates from remote URLs. Handlebars.java needs a little help to support this, hence the proxy of URLTemplateLoader.

Is this something you'd be willing to support in hbs?