### PR TITLE
add defhelper-missing macro

### DIFF
--- a/src/hbs/helper.clj
+++ b/src/hbs/helper.clj
@@ -13,6 +13,14 @@
        (reify Helper
          (apply ~argvec ~@body)))))
 
+(defmacro defhelper-missing
+  "Define the missing-helper helper."
+  [argvec & body]
+  (let [argvec (into [] (concat [(gensym)] argvec))]
+    `(.registerHelperMissing ^Handlebars *hbs*
+                             (reify Helper
+                               (apply ~argvec ~@body)))))
+
 (defprotocol HandlebarsOptions
   (param [this idx])
   (hash [this key])

--- a/test/hbs/helper_test.clj
+++ b/test/hbs/helper_test.clj
@@ -1,7 +1,11 @@
 (ns hbs.helper-test
-  (:require [clojure.test :refer :all] 
-            [hbs.core :refer :all] 
-            [hbs.helper :refer :all :exclude [hash]]))
+  (:require [clojure.test :refer :all]
+            [hbs.core :refer :all]
+            [hbs.helper :refer :all :exclude [hash]]
+            [clojure.edn])
+  (:import [com.github.jknack.handlebars Handlebars]
+           [com.github.jknack.handlebars.io ClassPathTemplateLoader]
+           [com.github.jknack.handlebars.cache ConcurrentMapTemplateCache]))
 
 (deftest test-use-javascript-helpers
   (testing "test usage of javascript helpers"
@@ -9,3 +13,38 @@
            (do
              (register-js-helpers! "dev-resources/helpers/helpers.js")
              (render "{{js-helper foo}}" {:foo "bar"}))))))
+
+(deftest defhelper-test
+  (testing "defines a custom helper"
+    (binding [*hbs* (doto (Handlebars. (ClassPathTemplateLoader.))
+                      (.with (ConcurrentMapTemplateCache.)))]
+      (let [context {:foo "bar"}
+            params ["baz" "qux"]]
+        (defhelper test-helper
+          [ctx options]
+          (safe-str
+           (pr-str {:name (.-helperName options)
+                    :ctx ctx
+                    :params (into [] (.-params options))})))
+        (is (= {:name "test-helper"
+                :ctx (:foo context)
+                :params params}
+               (clojure.edn/read-string (render "{{test-helper foo baz qux}}"
+                                                {:foo "bar" :baz "baz" :qux "qux"}))))))))
+
+(deftest defhelper-missing-test
+  (testing "defines the helper that gets used when none of that name exists"
+    (binding [*hbs* (doto (Handlebars. (ClassPathTemplateLoader.))
+                      (.with (ConcurrentMapTemplateCache.)))]
+      (let [context {:foo "bar"}
+            params ["baz" "qux"]]
+        (defhelper-missing [ctx options] (safe-str
+                                          (pr-str
+                                           {:name (.-helperName options)
+                                            :ctx ctx
+                                            :params (into [] (.-params options))})))
+        (is (= {:name "missing-helper"
+                :ctx (:foo context)
+                :params params}
+               (clojure.edn/read-string (render "{{missing-helper foo baz qux}}"
+                                                {:foo "bar" :baz "baz" :qux "qux"}))))))))


### PR DESCRIPTION
Allows defining a helperMissing helper.

See "Helper missing" on this page:
https://jknack.github.io/handlebars.java/helpers.html