### PR TITLE
Fix 2-arity render-file

### DIFF
--- a/src/hbs/core.clj
+++ b/src/hbs/core.clj
@@ -42,7 +42,7 @@
 
 (defn render-file
   "Render ctx with a template name."
-  ([tpl-name ctx] (render *hbs* tpl-name ctx))
+  ([tpl-name ctx] (render-file *hbs* tpl-name ctx))
   ([reg tpl-name ctx]
    (.apply ^Template (.compile ^Handlebars reg ^String tpl-name)
            (wrap-context ctx))))


### PR DESCRIPTION
2-arity render-file is incorrectly calling 3-arity render instead of 3-arity render-file.

This fixes a bug where calling 2-arity render-file returns the string name of the template instead of rendering the template (since the the template name is accidentally evaluated as an inline template).